### PR TITLE
Add TouchID to authentication options

### DIFF
--- a/src/features/info.js
+++ b/src/features/info.js
@@ -63,7 +63,7 @@ const faq_entries = [
                 <li>Begegnungsmitteilungen</li>
                 <li>Status von Begegnungsaufzeichnungen</li>
                 <li>Begegnungsüberprüfungen</li>
-                <li>Mit PIN oder FaceID authentifizieren</li>
+                <li>Mit FaceID, TouchID oder PIN authentifizieren</li>
                 <li>ganz nach unten scrollen</li>
                 <li>Überprüfungen exportieren</li>
             </ul>


### PR DESCRIPTION
Until now there was only FaceID or PIN, but older iPhones are using TouchID, I've added this to the Text under `Information`.

Hope this Change is welcome and thank you so much for this great tool! 